### PR TITLE
Replace installation url with a working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install .
 or
 
 ```bash
-pip install git@github.com:{USER_NAME}/{REPO_NAME}.git
+pip install git+https://github.com/{USER_NAME}/{REPO_NAME}.git
 ```
 
 and replace `{USER_NAME}` and `{REPO_NAME}` by your own details. 


### PR DESCRIPTION
The old version of the url doesn't work for me (and I have had complaints from others. Maybe test again, but I think this will fix it.